### PR TITLE
update to use iter_utterances instead of accessing private variables

### DIFF
--- a/convokit/politenessStrategies/politenessStrategies.py
+++ b/convokit/politenessStrategies/politenessStrategies.py
@@ -76,7 +76,7 @@ class PolitenessStrategies(Transformer):
         :param markers: whether or not to add politeness occurrence markers
         """
 
-        total_utts = len(corpus.utterances)
+        total_utts = len(corpus.iter_utterances())
 
         for idx, utt in enumerate(corpus.iter_utterances()):
 

--- a/convokit/text_processing/textProcessor.py
+++ b/convokit/text_processing/textProcessor.py
@@ -52,7 +52,7 @@ class TextProcessor(Transformer):
         :return: the corpus
         """
 
-        total_utts = len(corpus.utterances)
+        total_utts = len(corpus.iter_utterances())
 
         for idx, utterance in enumerate(corpus.iter_utterances()):
 


### PR DESCRIPTION
### Description
Minor issue that never got changed since issue #140 was closed: `politenessStrategies.py` and `textProcessor.py` accesses private variable `corpus.utterances` in line 79 and line 55 respectively, and i remember mentioning that code should not access corpus private variables outside of the corpus file and should use the getters instead like `corpus.iter_utterances()`.