### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![pypi](https://img.shields.io/pypi/v/convokit.svg)](https://pypi.org/pypi/convokit/)
-[![py\_versions](https://img.shields.io/badge/python-3.6%2B-blue)](https://pypi.org/pypi/convokit/)
+[![py\_versions](https://img.shields.io/badge/python-3.7%2B-blue)](https://pypi.org/pypi/convokit/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![license](https://img.shields.io/badge/license-MIT-green)](https://github.com/CornellNLP/ConvoKit/blob/master/LICENSE.md)
 [![Slack Community](https://img.shields.io/static/v1?logo=slack&style=flat&color=red&label=slack&message=community)](https://join.slack.com/t/convokit/shared_invite/zt-1axq34qrp-1hDXQrvSXClIbJOqw4S03Q)

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -59,8 +59,6 @@ The two recommended fixes are to run:
 
 and if that doesn't fix the issue, then run:
 
->>> open /Applications/Python\ 3.6/Install\ Certificates.command
+>>> open /Applications/Python\ 3.7/Install\ Certificates.command
 
-(Substitute 3.6 in the above command with your current Python version (e.g. 3.7 or 3.8) if necessary.)
-
-
+(Substitute 3.7 in the above command with your current Python version (e.g. 3.8 or 3.9) if necessary.)

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -5,7 +5,7 @@ Introductory tutorial
 Setup
 =====
 
-This toolkit requires Python >=3.6.
+This toolkit requires Python >=3.7.
 
 If you haven't already,
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "nltk>=3.4",
         "dill>=0.2.9",
         "joblib>=0.13.2",
-        "clean-text>=0.1.1",
+        "clean-text>=0.6.0",
         "unidecode>=1.1.1",
         "tqdm>=4.64.0",
     ],
@@ -59,8 +59,8 @@ setup(
     },
     classifiers=[
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )


### PR DESCRIPTION
### Description
Python 3.6 has reached its [end of life](https://endoflife.date/python), meaning packages in general will stop making updates to support it. We should accordingly drop support as well, as maintaining support for Python 3.6 will lead to dependency issues as other packages drop support for it.

This has already happened for our `clean-text` dependency: https://github.com/CornellNLP/ConvoKit/pull/170#issuecomment-1186366428.

### Motivation and Context
Further context re: `clean-text`

As of `v0.6.0`, `clean-text` actually correctly sets its requirements to an older version of emoji. However, right now, when running the 3.6 workflow, it attempts to install `v0.5.0` instead, which installs the latest emoji (aka 2.0.0). The reason it does this is because `v0.6.0` does not support Python 3.6, as of 6 months ago, which coincides with the end-of-life date for Python 3.6.

In other words, the Python 3.6 workflow failure can only be fixed if we update the lowest Python version for ConvoKit to 3.7, so it uses an up-to-date version of `clean-text`

### How has this been tested?
Workflow tests.
