### PR TITLE
Add workflow to sync download_config.json

### DIFF
--- a/.github/workflows/rsync-download-config.yml
+++ b/.github/workflows/rsync-download-config.yml
@@ -1,0 +1,21 @@
+name: Sync download_config.json
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: rsync download config
+      uses: burnett01/rsync-deployments@master
+      with:
+        switches: -vzr
+        path: download_config.json
+        remote_path: ${{ secrets.DEPLOY_DOCS_PATH }}
+        remote_host: ${{ secrets.DEPLOY_HOST }}
+        remote_user: ${{ secrets.DEPLOY_USER }}
+        remote_key: ${{ secrets.DEPLOY_KEY }}


### PR DESCRIPTION
### Description
We need to update `download_config.json` on the server any time a change happens to `download_config.json` in repo. 

Since all the older ConvoKit versions point to https://zissou.infosci.cornell.edu/convokit/datasets/download_config.json, we have keep this up-to-date with repo.

This PR adds a workflow to `rsync` the repo download config to server. The original path will be soft-linked to this rsync output path.

### Motivation and Context
As described.