### PR TITLE
Small fixes for expected context transformer model

### DIFF
--- a/convokit/expected_context_framework/expected_context_model.py
+++ b/convokit/expected_context_framework/expected_context_model.py
@@ -698,17 +698,17 @@ class ExpectedContextModel:
         self.snip_first_dim = meta_dict["snip_first_dim"]
         self.cluster_on = meta_dict["cluster_on"]
 
-        self.context_U = np.load(os.path.join(dirname, "context_U.npy"))
+        self.context_U = np.load(os.path.join(dirname, "context_U.npy"), allow_pickle=True)
         self.train_context_reprs = self._snip(self.context_U, self.snip_first_dim)
-        self.context_V = np.load(os.path.join(dirname, "context_V.npy"))
+        self.context_V = np.load(os.path.join(dirname, "context_V.npy"), allow_pickle=True)
         self.context_term_reprs = self._snip(self.context_V, self.snip_first_dim)
-        self.context_s = np.load(os.path.join(dirname, "context_s.npy"))
-        self.context_terms = np.load(os.path.join(dirname, "context_terms.npy"))
-        self.terms = np.load(os.path.join(dirname, "terms.npy"))
-        self.term_reprs_full = np.matrix(np.load(os.path.join(dirname, "term_reprs.npy")))
+        self.context_s = np.load(os.path.join(dirname, "context_s.npy"), allow_pickle=True)
+        self.context_terms = np.load(os.path.join(dirname, "context_terms.npy"), allow_pickle=True)
+        self.terms = np.load(os.path.join(dirname, "terms.npy"), allow_pickle=True)
+        self.term_reprs_full = np.matrix(np.load(os.path.join(dirname, "term_reprs.npy"), allow_pickle=True))
         self.term_reprs = self._snip(self.term_reprs_full, self.snip_first_dim)
-        self.term_ranges = np.load(os.path.join(dirname, "term_ranges.npy"))
-        self.train_utt_reprs = np.load(os.path.join(dirname, "train_utt_reprs.npy"))
+        self.term_ranges = np.load(os.path.join(dirname, "term_ranges.npy"), allow_pickle=True)
+        self.train_utt_reprs = np.load(os.path.join(dirname, "train_utt_reprs.npy"), allow_pickle=True)
 
         try:
             km_obj = ClusterWrapper(self.n_clusters)
@@ -818,7 +818,7 @@ class ClusterWrapper:
         self.random_state = meta_dict["random_state"]
 
         self.km_df = pd.read_csv(os.path.join(dirname, "cluster_km_df.tsv"), sep="\t", index_col=0)
-        self.cluster_names = np.load(os.path.join(dirname, "cluster_names.npy"))
+        self.cluster_names = np.load(os.path.join(dirname, "cluster_names.npy"), allow_pickle=True)
         self.km_model = joblib.load(os.path.join(dirname, "km_model.joblib"))
 
     def dump(self, dirname):

--- a/convokit/expected_context_framework/expected_context_model.py
+++ b/convokit/expected_context_framework/expected_context_model.py
@@ -705,10 +705,14 @@ class ExpectedContextModel:
         self.context_s = np.load(os.path.join(dirname, "context_s.npy"), allow_pickle=True)
         self.context_terms = np.load(os.path.join(dirname, "context_terms.npy"), allow_pickle=True)
         self.terms = np.load(os.path.join(dirname, "terms.npy"), allow_pickle=True)
-        self.term_reprs_full = np.matrix(np.load(os.path.join(dirname, "term_reprs.npy"), allow_pickle=True))
+        self.term_reprs_full = np.matrix(
+            np.load(os.path.join(dirname, "term_reprs.npy"), allow_pickle=True)
+        )
         self.term_reprs = self._snip(self.term_reprs_full, self.snip_first_dim)
         self.term_ranges = np.load(os.path.join(dirname, "term_ranges.npy"), allow_pickle=True)
-        self.train_utt_reprs = np.load(os.path.join(dirname, "train_utt_reprs.npy"), allow_pickle=True)
+        self.train_utt_reprs = np.load(
+            os.path.join(dirname, "train_utt_reprs.npy"), allow_pickle=True
+        )
 
         try:
             km_obj = ClusterWrapper(self.n_clusters)

--- a/convokit/expected_context_framework/expected_context_model.py
+++ b/convokit/expected_context_framework/expected_context_model.py
@@ -594,7 +594,7 @@ class ExpectedContextModel:
         return self._snip(utt_vects * self.term_reprs_full / self.context_s, self.snip_first_dim)
 
     def compute_utt_ranges(self, utt_vects):
-        return np.dot(normalize(utt_vects, norm="l1"), self.term_ranges)
+        return np.dot(normalize(np.array(utt_vects), norm="l1"), self.term_ranges)
 
     def transform_context_utts(self, context_utt_vects):
         return self._snip(context_utt_vects * self.context_V / self.context_s, self.snip_first_dim)
@@ -761,7 +761,7 @@ class ExpectedContextModel:
     def _snip(self, vects, snip_first_dim=True, dim=None):
         if dim is None:
             dim = vects.shape[1]
-        return normalize(vects[:, int(snip_first_dim) : dim])
+        return normalize(np.array(vects[:, int(snip_first_dim) : dim]))
 
 
 class ClusterWrapper:


### PR DESCRIPTION
### Description
This PR includes small fixes to the Expected Context Transformer Model to account for changes in numpy and sklearn dependencies. 
1. Change use of sklearn `normalize` to ensure we are passing in numpy array and not numpy matrix since use of `normalize` and other linear algebra operations for matrices are being deprecated [here](https://numpy.org/doc/stable/reference/generated/numpy.matrix.html). 
2. Set `allow_pickle` field to True when loading Expected Context saved files since they contain objects. This field is now default to False as of numpy version 1.16.3 [here](https://numpy.org/devdocs/reference/generated/numpy.load.html). 


### How has this been tested?
Manually.

### Other information
Note the change in `np.load` may affect loading of other models if they save pickled data.