### PR TITLE
Unsloth truncation errors 

### DIFF
--- a/convokit/utterance_simulator/unslothUtteranceSimulatorModel.py
+++ b/convokit/utterance_simulator/unslothUtteranceSimulatorModel.py
@@ -199,7 +199,17 @@ class UnslothUtteranceSimulatorModel(UtteranceSimulatorModel):
         utt_ids = []
         for data in tqdm(test_dataset):
             text = data["text"]
-            inputs = self.tokenizer(text, return_tensors="pt").to(self.device)
+            inputs = self.tokenizer(
+                text,
+                return_tensors="pt",
+                padding=True,
+                truncation=True,
+                max_length=self.model_config["max_seq_length"],
+            ).to(self.device)
+            assert inputs["input_ids"].shape[1] <= self.model_config["max_seq_length"], (
+                f"Input length {inputs['input_ids'].shape[1]} exceeds max_seq_length "
+                f"{self.model_config['max_seq_length']}"
+            )
             input_len = inputs["input_ids"].shape[1]
             responses = self.model.generate(
                 **inputs,


### PR DESCRIPTION
Without intervention, transforming a CGA-CMV corpus using the pivotal moments demo notebook will sometimes cause the following error:
```RuntimeError: The size of tensor a (2049) must match the size of tensor b (2122) at non-singleton dimension 3```
The attention_mask and inputs length mismatch can be resolved in the UnslothUtteranceSimulatorModel by specifying the parameters to truncate at the model's max_seq_length.