### PR TITLE
Improve Model Loading Logic for TransformerDecoderModel

### DIFF
--- a/convokit/forecaster/TransformerDecoderModel.py
+++ b/convokit/forecaster/TransformerDecoderModel.py
@@ -28,8 +28,8 @@ def _get_template_map(model_name_or_path):
     :raises ValueError: If the model is not recognized.
     """
     TEMPLATE_PATTERNS = [
-        ("google/gemma-2", "gemma2"),
-        ("google/gemma-3", "gemma3"),
+        ("gemma-2", "gemma2"),
+        ("gemma-3", "gemma3"),
         ("mistral", "mistral"),
         ("zephyr", "zephyr"),
         ("phi-4", "phi-4"),

--- a/convokit/forecaster/TransformerDecoderModel.py
+++ b/convokit/forecaster/TransformerDecoderModel.py
@@ -19,7 +19,7 @@ from .TransformerForecasterConfig import TransformerForecasterConfig
 import shutil
 
 
-def _get_templet_map(model_name_or_path):
+def _get_template_map(model_name_or_path):
     """
     Map a model name or path to its corresponding prompt template family.
 
@@ -28,12 +28,12 @@ def _get_templet_map(model_name_or_path):
     :raises ValueError: If the model is not recognized.
     """
     TEMPLATE_PATTERNS = [
-        ("google/gemma-2-", "gemma2"),
-        ("google/gemma-3-", "gemma3"),
-        ("mistralai/mistral", "mistral"),
-        ("HuggingFaceH4/zephyr", "zephyr"),
-        ("microsoft/phi-4", "phi-4"),
-        ("meta-llama/Llama-3", "llama3"),
+        ("google/gemma-2", "gemma2"),
+        ("google/gemma-3", "gemma3"),
+        ("mistral", "mistral"),
+        ("zephyr", "zephyr"),
+        ("phi-4", "phi-4"),
+        ("llama-3", "llama3"),
     ]
 
     for pattern, template in TEMPLATE_PATTERNS:
@@ -84,7 +84,7 @@ class TransformerDecoderModel(ForecasterModel):
 
         self.tokenizer = get_chat_template(
             tokenizer,
-            chat_template=_get_templet_map(model_name_or_path),  # TO-DO: Define this
+            chat_template=_get_template_map(self.model.config.name_or_path),
             mapping={"role": "from", "content": "value", "user": "human", "assistant": "model"},
         )
         # Custom prompt


### PR DESCRIPTION
### Description
This pull request resolves an issue with loading fine-tuned TransformerDecoderModel forecasters.

### Motivation and Context
Previously, the model loading logic relied on user-provided paths, which could lead to errors if the saved path did not correctly include the model’s name (i.e. google/gemma-3-9b-it). This PR introduces a more robust approach that reduces the risk of such user mistakes by ensuring the model name is correctly inferred during loading.

### How has this been tested?
The updated loading mechanism has been validated through unit tests and manual verification by Son Tran and Laerdon Kim.
